### PR TITLE
Include routine to get rv-include attribute

### DIFF
--- a/rivets-include.js
+++ b/rivets-include.js
@@ -101,7 +101,8 @@
       if (this.clear) this.clear();
     },
     routine: function(el, value) {
-      this.load(value);
+      var path = el.getAttribute('rv-include')
+      this.load(path);
     }
   };
 });


### PR DESCRIPTION
`value` isnt defined, the proper input is the `rv-include` attribute? think so
